### PR TITLE
Extract all links that start with #viewer-

### DIFF
--- a/itemlist_schema_gen.py
+++ b/itemlist_schema_gen.py
@@ -24,7 +24,8 @@ def generate_itemlist(url):
     soup = BeautifulSoup(r.content, 'html.parser')
 
     # Find the anchorViewer elements
-    anchors = soup.find_all('a', {'data-hook': 'anchorViewer'})
+    anchors = soup.find_all('a', href=lambda href: href and href.startswith('#viewer-'))
+
 
     if not anchors:
         st.error(f"No anchorViewer elements found in the page: {url}")


### PR DESCRIPTION
Ricos and blog change rendering method and not use any more data-hook: anchorViewer. I changed the script to extract URLs that conatin #viewer-.